### PR TITLE
Gradle Build Fix

### DIFF
--- a/src/commonMain/kotlin/io/github/katerinapetrova/mpplib/Base64.kt
+++ b/src/commonMain/kotlin/io/github/katerinapetrova/mpplib/Base64.kt
@@ -5,7 +5,7 @@ interface Base64Encoder {
     fun encodeToString(src: ByteArray): String {
         val encoded = encode(src)
         return buildString(encoded.size) {
-            encoded.forEach { append(it.toChar()) }
+            encoded.forEach { append(it.toInt().toChar()) }
         }
     }
 }


### PR DESCRIPTION
toChar() method on Byte class is deprecated and build fails on Java 11 and above. As recommended by JDK, the commit converts Bytes to int, followed by converting it to char